### PR TITLE
change operator's apiVersion from apps/v1beta1 to apps/v1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node {
         stage ('Deploy to production') {
             writeFile file: 'operator.yaml', text: """
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq-operator
@@ -64,7 +64,7 @@ spec:
         stage ('Deploy to sandbox') {
             writeFile file: 'operator.yaml', text: """
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq-operator

--- a/deploy/deploy-operator-debug/operator-debug.yaml
+++ b/deploy/deploy-operator-debug/operator-debug.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq-operator

--- a/deploy/deploy-operator-default/operator.yaml
+++ b/deploy/deploy-operator-default/operator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq-operator


### PR DESCRIPTION
For Issue #15 
```
$ kubectl apply -f deploy/deploy-operator-default/operator.yaml
service/rabbitmq-operator created
error: unable to recognize "deploy/deploy-operator-default/operator.yaml": no matches for kind "Deployment" in version "apps/v1beta1"
```
